### PR TITLE
Add additional config parameters

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,10 @@ AllCops:
   ExtraDetails: true
   DisplayStyleGuide: true
 
+  # the default CacheRootDirectory is no longer `/tmp`, but a directory under
+  # `$HOME` and some Unix platforms use symlink to that path
+  AllowSymlinksInCacheRootDirectory: true
+
 Style/StringLiterals:
   # https://github.com/reallyenglish/ansible-role-example/issues/60#issuecomment-280573231
   EnforcedStyle: double_quotes

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,10 +44,10 @@ script:
   - rvm use 2.1.10
 
   # download the QA scripts
-  - git clone https://github.com/reallyenglish/qansible.git
+  - git clone https://github.com/trombik/qansible.git
 
-  # checkout the reallyengnlish-master branch
-  - ( cd qansible && git checkout reallyenglish-master )
+  # checkout the latest release
+  - ( cd qansible && git checkout $(git describe --tags $(git rev-list --tags --max-count=1)) )
 
   # install it
   - ( cd qansible && bundle install --path vendor/bundle --with "test" && bundle exec rake build && gem install pkg/*.gem )

--- a/README.md
+++ b/README.md
@@ -42,15 +42,48 @@ None
 | rsyslog\_conf\_file | path to rsyslog.conf | {{ \_\_rsyslog\_conf\_file }} |
 | rsyslog\_bin | path to rssylogd binary | {{ \_\_rsyslog\_bin }} |
 | rsyslog\_mode | array of mode to run as. `local` acts as local syslog, logs to local files. `client` acts as a syslog client, forwards logs to remote host. `server` act as a syslog server, receives logs from remote. | ["local"] |
-| rsyslog\_remote\_servers | array of remote syslog servers in the form of [ remote.example.com:514 ] | [] |
+| rsyslog\_remote\_servers | a dict of remote-server inputs. see below | {} |
 | rsyslog\_default\_syslog\_service\_name | service name of existing syslog service, which will be stopped and disabled | {{ \_\_rsyslog\_default\_syslog\_service\_name }} |
 | rsyslog\_default\_log\_files | TBW | {{ \_\_rsyslog\_default\_log\_files }} |
 | rsyslog\_config\_WorkDirectory | WorkDirectory | /var/spool/rsyslog |
 | rsyslog\_config\_FileOwner | FileOwner | {{ \_\_rsyslog\_config\_FileOwner }} |
 | rsyslog\_config\_FileGroup | FileGroup | {{ \_\_rsyslog\_config\_FileGroup }} |
+| rsyslog\_config\_FileCreateMode | FileCreateMode | 0640 |
+| rsyslog\_config\_DirCreateMode | DirCreateMode | 0755 |
+| rsyslog\_config\_Umask | Umask | 0022 |
+| rsyslog\_config\_PreserveFQDN | PreserveFQDN | 'on' |
 | rsyslog\_imfile\_inputs | a dict of imfile inputs. see below | {} |
+| rsyslog\_imuxsock\_inputs | a dict of imfile inputs. see below | {} |
 | rsyslog\_server\_config\_AllowedSender | when rsyslog\_mode is 'server', a list of allowed clients | [] |
 | rsyslog\_server\_config\_listen\_port | when rsyslog\_mode is 'server', a list of ports that `rsyslogd` will listen on | {{ \_\_rsyslog\_server\_config\_listen\_port }} |
+
+## rsyslog\_remote\_servers
+
+rsyslog\_remote\_servers is a list of hashes remote servers to which to send logs.
+
+```yaml
+rsyslog_remote_servers:
+  remote.example.com:
+    host: remote.example.com
+    port: 514
+    retry_count: 3
+    facilities: kern,auth,daemon
+    severities: emerg,alert,crit,err
+    transport: udp
+    queue_quota: 1g
+```
+
+`host` is the only required property - this is used as the network identifier (i.e. hostname or IP) of the remote server.
+what follows is a list of the optional properties that can be included on a per-server basis, and the default values they have when omitted.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `port` | remote port to connect to | `514` |
+| `retry_count` | number of times to retry a failed send (`-1` means retry forever) | `-1` |
+| `facilities` | facilities to send to this server (`*` mean all facilities) | `*` |
+| `severities` | severities to sent to this server (`*` means all severities) | `*` |
+| `transport` | transport protocol by which to connect to remote server (`tcp` or `udp`) | `tcp` |
+| `queue_quota` | disk quota for messages spooled in this queue. if not provided, this parameter is omitted from the config. | --- |
 
 ## rsyslog\_imfile\_inputs
 
@@ -62,9 +95,21 @@ rsyslog_imfile_inputs:
     path: /tmp/dummy.log
     tag: dummy
     facility: local1
+    severity: info
+    persistent_state_interval: 10
 ```
 
-this creates a config flagment like:
+in this example, only the `path` and `tag` properties are required. the remaining properties have defaults as follows:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `facility` | facility for events gathered from this source | `local0` |
+| `severity` | severity for events gathered from this source | `notice` |
+| `persistent_state_interval` | save read state to disk every *n* lines. if not provided, this parameter is omitted from the config, and state is *not saved*. | --- |
+
+see <http://www.rsyslog.com/doc/v8-stable/configuration/modules/imfile.html#input-parameters> for details about how `PersistentStateInterval` works.
+
+the example given above creates a config fragment like this:
 
 ```
 input(
@@ -72,6 +117,47 @@ input(
   File="/tmp/dummy.log"
   Tag="dummy"
   Facility="local1"
+  Severity="info"
+  PersistentStateinterval="10"
+)
+```
+
+## rsyslog\_imuxsock\_inputs
+
+rsyslog\_imuxsock\_inputs is a hash of files to read.
+
+```yaml
+rsyslog_imuxsock_inputs:
+  dummy.sock:
+    path: /var/run/dummy.sock
+    ignore_own_messages: off
+    flow_control: on
+    use_system_pid: on
+    create_path: on
+    host_name: fnord.example.com
+```
+
+in this example, only the `path` property is required. the remaining properties have defaults as follows:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `ignore_own_messages` | discard messages received from the same instance of syslog | `on` |
+| `flow_control` | use flow control on the specified UNIX domain socket | `off` |
+| `use_system_pid` | obtain logged PID from the socket itself | `on` |
+| `create_path` | create directory path to the socket file if it doesn't exist | `off` |
+| `host_name` | override the reported hostname for logged events. if not provided, this parameter is omitted from the config. | --- |
+
+the example given above creates a config fragment like this:
+
+```
+input(
+  type="imuxsock"
+  Socket="/var/run/dummy.sock"
+  IgnoreOwnMessages="off"
+  FlowControl="on"
+  UsePIDFromSystem="on"
+  CreatePath="on"
+  HostName="fnord.example.com"
 )
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,9 +21,9 @@ rsyslog_default_syslog_service_name: "{{ __rsyslog_default_syslog_service_name }
 rsyslog_config_WorkDirectory: "/var/spool/rsyslog"
 rsyslog_config_FileOwner: "{{ __rsyslog_config_FileOwner }}"
 rsyslog_config_FileGroup: "{{ __rsyslog_config_FileGroup }}"
-rsyslog_config_FileCreateMode: 0640
-rsyslog_config_DirCreateMode: 0755
-rsyslog_config_Umask: 0022
+rsyslog_config_FileCreateMode: '0640'
+rsyslog_config_DirCreateMode: '0755'
+rsyslog_config_Umask: '0022'
 rsyslog_config_PreserveFQDN: 'on'
 
 rsyslog_imfile_inputs: {}
@@ -32,15 +32,10 @@ rsyslog_imfile_Facility: 'local0'
 rsyslog_imfile_Severity: 'notice'
 
 rsyslog_imuxsock_inputs: {}
-rsyslog_imuxsock_IgnoreOwnMesages: 'on'
+rsyslog_imuxsock_IgnoreOwnMessages: 'on'
 rsyslog_imuxsock_FlowControl: 'off'
 rsyslog_imuxsock_UsePIDFromSystem: 'on'
 rsyslog_imuxsock_CreatePath: 'off'
-
-rsyslog_imfile_IgnoreOwnMessages: 'off'
-rsyslog_imfile_FlowControl: 'off'
-rsyslog_imfile_UsePidFromSystem: 'on'
-rsyslog_imfile_CreatePath: 'off'
 
 rsyslog_server_config_AllowedSender: []
 rsyslog_server_config_listen_port: "{{ __rsyslog_server_config_listen_port }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,12 @@ rsyslog_bin: "{{ __rsyslog_bin }}"
 rsyslog_mode:
   - local
 
-rsyslog_remote_servers: []
+rsyslog_remote_servers: {}
+
+rsyslog_client_Port: '514'
+rsyslog_client_RetryCount: '-1'
+rsyslog_client_Facilities: '*'
+rsyslog_client_Severities: '*'
 
 # the service name of the default syslog service
 rsyslog_default_syslog_service_name: "{{ __rsyslog_default_syslog_service_name }}"
@@ -16,7 +21,26 @@ rsyslog_default_syslog_service_name: "{{ __rsyslog_default_syslog_service_name }
 rsyslog_config_WorkDirectory: "/var/spool/rsyslog"
 rsyslog_config_FileOwner: "{{ __rsyslog_config_FileOwner }}"
 rsyslog_config_FileGroup: "{{ __rsyslog_config_FileGroup }}"
+rsyslog_config_FileCreateMode: 0640
+rsyslog_config_DirCreateMode: 0755
+rsyslog_config_Umask: 0022
+rsyslog_config_PreserveFQDN: 'on'
+
 rsyslog_imfile_inputs: {}
+
+rsyslog_imfile_Facility: 'local0'
+rsyslog_imfile_Severity: 'notice'
+
+rsyslog_imuxsock_inputs: {}
+rsyslog_imuxsock_IgnoreOwnMesages: 'on'
+rsyslog_imuxsock_FlowControl: 'off'
+rsyslog_imuxsock_UsePIDFromSystem: 'on'
+rsyslog_imuxsock_CreatePath: 'off'
+
+rsyslog_imfile_IgnoreOwnMessages: 'off'
+rsyslog_imfile_FlowControl: 'off'
+rsyslog_imfile_UsePidFromSystem: 'on'
+rsyslog_imfile_CreatePath: 'off'
 
 rsyslog_server_config_AllowedSender: []
 rsyslog_server_config_listen_port: "{{ __rsyslog_server_config_listen_port }}"

--- a/tasks/configure-client.yml
+++ b/tasks/configure-client.yml
@@ -3,7 +3,8 @@
 - name: Create 200_client.cfg
   template:
     src: 200_client.cfg.j2
-    dest: "{{ rsyslog_conf_dir }}/200_client.cfg"
+    dest: "{{ rsyslog_conf_dir }}/200_client_{{ item.key }}.cfg"
     validate: "{{ rsyslog_bin }} -N 1 -f %s"
+  with_dict: "{{ rsyslog_remote_servers }}"
   notify:
     - Restart rsyslog

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,12 +4,12 @@
 - include_vars: "{{ ansible_os_family }}.yml"
 
 - name: Reconfigure the stock syslogd(8) on OpenBSD
-  include: configure-OpenBSD-syslogd.yml
+  include_tasks: configure-OpenBSD-syslogd.yml
   when:
     - "{{ ansible_os_family == 'OpenBSD' }}"
     - "{{ 'local' in rsyslog_mode }}"
 
-- include: "install-{{ ansible_os_family }}.yml"
+- include_tasks: "install-{{ ansible_os_family }}.yml"
 
 - name: Create WorkDirectory
   file:
@@ -25,15 +25,15 @@
 
 - name: Configure as client
   include: configure-client.yml
-  when: '"client" in rsyslog_mode'
+  when: "'client' in rsyslog_mode"
 
 - name: Configure as server
   include: configure-server.yml
-  when: '"server" in rsyslog_mode'
+  when: "'server' in rsyslog_mode"
 
 - name: Configure as local
   include: configure-local.yml
-  when: '"local" in rsyslog_mode'
+  when: "'local' in rsyslog_mode"
 
 - name: Create imfile inputs
   # XXX you cannot validate imfile fragments because they are not a valid

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,12 +36,22 @@
   when: '"local" in rsyslog_mode'
 
 - name: Create imfile inputs
-  # XXX you cannot validate imfile flagments because they are not a valid
+  # XXX you cannot validate imfile fragments because they are not a valid
   # config themselves
   template:
     src: imfile.cfg.j2
     dest: "{{ rsyslog_conf_dir }}/900_{{ item.key }}.cfg"
   with_dict: "{{ rsyslog_imfile_inputs }}"
+  notify:
+    - Restart rsyslog
+
+- name: Create imuxsock inputs
+  # XXX you cannot validate imfile fragments because they are not a valid
+  # config themselves
+  template:
+    src: imuxsock.cfg.j2
+    dest: "{{ rsyslog_conf_dir }}/900_{{ item.key }}.cfg"
+  with_dict: "{{ rsyslog_imuxsock_inputs }}"
   notify:
     - Restart rsyslog
 

--- a/templates/200_client.cfg.j2
+++ b/templates/200_client.cfg.j2
@@ -8,9 +8,7 @@ $ActionQueueMaxDiskSpace {{ item.value.queue_quota }}
 
 {{ item.value.facilities | default(rsyslog_client_Facilities) -}}
 .
-{{- item.value.severities | default(rsyslog_client_Severities) -}}
- {# <-- this space on this line is syntactic, it must be preserved #}
-{{- '@' if item.value.transport == 'udp' else '@@' }}
+{{- item.value.severities | default(rsyslog_client_Severities) }} {{ '@' if item.value.transport == 'udp' else '@@' -}}
 {{ item.value.host -}}
 :
 {{- item.value.port | default(rsyslog_client_Port) -}}

--- a/templates/200_client.cfg.j2
+++ b/templates/200_client.cfg.j2
@@ -1,8 +1,17 @@
-{% for server in rsyslog_remote_servers -%}
 $ActionQueueType LinkedList
-$ActionQueueFileName {{ server }}-queue
-$ActionResumeRetryCount -1
+$ActionQueueFileName {{ item.value.host }}-queue
+$ActionResumeRetryCount {{ item.value.retry_count | default(rsyslog_client_RetryCount) }}
 $ActionQueueSaveOnShutdown on
+{% if item.value.queue_quota is defined -%}
+$ActionQueueMaxDiskSpace {{ item.value.queue_quota }}
+{% endif -%}
 
-*.* @@{{ server }};RSYSLOG_ForwardFormat
-{% endfor -%}
+{{ item.value.facilities | default(rsyslog_client_Facilities) -}}
+.
+{{- item.value.severities | default(rsyslog_client_Severities) -}}
+ {# <-- this space on this line is syntactic, it must be preserved #}
+{{- '@' if item.value.transport == 'udp' else '@@' }}
+{{ item.value.host -}}
+:
+{{- item.value.port | default(rsyslog_client_Port) -}}
+;RSYSLOG_ForwardFormat

--- a/templates/imfile.cfg.j2
+++ b/templates/imfile.cfg.j2
@@ -2,5 +2,9 @@ input(
   type="imfile"
   File="{{ item.value.path }}"
   Tag="{{ item.value.tag }}"
-  Facility="{{ item.value.facility }}"
+  Facility="{{ item.value.facility | default(rsyslog_imfile_Facility)  }}"
+  Severity="{{ item.value.severity | default(rsyslog_imfile_Severity) }}"
+  {% if item.value.persistent_state_interval is defined -%}
+  PersistentStateInterval="{{ item.value.persistent_state_interval }}"
+  {% endif -%}
 )

--- a/templates/imuxsock.cfg.j2
+++ b/templates/imuxsock.cfg.j2
@@ -1,0 +1,11 @@
+input(
+  type="imuxsock"
+  Socket="{{ item.value.path }}"
+  IgnoreOwnMessages="{{ item.value.ignore_own_messages | default(rsyslog_imuxsock_IgnoreOwnMessages) }}"
+  FlowControl="{{ item.value.flow_control | default(rsyslog_imuxsock_FlowControl)  }}"
+  UsePIDFromSystem="{{ item.value.use_system_pid | default(rsyslog_imuxsock_UsePidFromSystem)  }}"
+  CreatePath="{{ item.value.create_path | default(rsyslog_imuxsock_CreatePath)  }}"
+  {% if item.value.host_name is defined -%}
+  HostName="{{ item.value.host_name }}"
+  {% endif -%}
+)

--- a/templates/imuxsock.cfg.j2
+++ b/templates/imuxsock.cfg.j2
@@ -3,7 +3,7 @@ input(
   Socket="{{ item.value.path }}"
   IgnoreOwnMessages="{{ item.value.ignore_own_messages | default(rsyslog_imuxsock_IgnoreOwnMessages) }}"
   FlowControl="{{ item.value.flow_control | default(rsyslog_imuxsock_FlowControl)  }}"
-  UsePIDFromSystem="{{ item.value.use_system_pid | default(rsyslog_imuxsock_UsePidFromSystem)  }}"
+  UsePIDFromSystem="{{ item.value.use_system_pid | default(rsyslog_imuxsock_UsePIDFromSystem)  }}"
   CreatePath="{{ item.value.create_path | default(rsyslog_imuxsock_CreatePath)  }}"
   {% if item.value.host_name is defined -%}
   HostName="{{ item.value.host_name }}"

--- a/templates/rsyslog.conf.j2
+++ b/templates/rsyslog.conf.j2
@@ -20,13 +20,12 @@ module(
 {% endif %}
 {% endif %}
 
-$PreserveFQDN on
-$DirCreateMode 0755
+$PreserveFQDN {{ rsyslog_config_PreserveFQDN }}
 $FileOwner {{ rsyslog_config_FileOwner }}
 $FileGroup {{ rsyslog_config_FileGroup }}
-$FileCreateMode 0640
-$DirCreateMode 0755
-$Umask 0022
+$FileCreateMode {{ rsyslog_config_FileCreateMode }}
+$DirCreateMode {{ rsyslog_config_DirCreateMode }}
+$Umask {{ rsyslog_config_Umask }}
 
 
 $WorkDirectory {{ rsyslog_config_WorkDirectory }}

--- a/tests/integration/example/group_vars/client
+++ b/tests/integration/example/group_vars/client
@@ -3,5 +3,5 @@ rsyslog_mode:
   - client
 
 rsyslog_remote_servers:
-  - 192.168.21.200:514
-
+  - host: 192.168.21.200
+    port: 514

--- a/tests/serverspec/default.yml
+++ b/tests/serverspec/default.yml
@@ -7,7 +7,11 @@
   vars:
     rsyslog_mode: "{% if ansible_os_family == 'OpenBSD' %}[ 'local', 'server', 'client' ]{% else %}[ 'local', 'client' ]{% endif %}"
     rsyslog_remote_servers:
-      - 10.0.2.115:514
+      - host: '10.0.2.115'
+        port: 514
+        transport: 'tcp'
+        queue_quota: '1g'
+        default_template: 'RSYSLOG_TraditionalFileFormat'
     rsyslog_imfile_inputs: "{% if ansible_os_family == 'OpenBSD' %}{}{% else %}{ 'dummy.log': { 'path': '/tmp/dummy.log', 'tag': 'dummy', 'facility': 'local1' } }{% endif %}"
     rsyslog_server_config_AllowedSender: "{% if ansible_os_family == 'OpenBSD' %}[ 'UDP, 127.0.0.1' ]{% else %}[]{% endif %}"
 #      dummy.log:


### PR DESCRIPTION
Added support for specifying the value of several parameters on imfiles
and on general client behavior.

This branch changes the structure of the `rsyslog_remote_servers` variable, and is not backwards-compatible.

Also added support for imuxsock input type.

Also updated README.md to reflect changed format for `rsyslog_remote_servers` and other new supported parameters.